### PR TITLE
Prevent multiple definitions of adl_info

### DIFF
--- a/include/magic_enum/magic_enum.hpp
+++ b/include/magic_enum/magic_enum.hpp
@@ -203,7 +203,7 @@ struct adl_info_holder {
     constexpr static adl_info_holder<IsFlags,Min,Max,prefix_len> prefix() { return {};}
 };
 
-adl_info_holder<> adl_info()
+static inline adl_info_holder<> adl_info()
 {
      return {};
 }


### PR DESCRIPTION
As currently implemented, `adl_info` can potentially be defined wherever `magic_enum.hpp` is included, this can lead to linker errors downstream.

Making the function static-inline prevents this from happening.